### PR TITLE
Renamed ImGuiOverlay to EditorUI

### DIFF
--- a/Editor/Source/Private/AssetBrowser.cpp
+++ b/Editor/Source/Private/AssetBrowser.cpp
@@ -3,12 +3,12 @@
 #include <iostream>
 
 #include <Core/Scene.h>
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 
 namespace Nightbird
 {
-	AssetBrowser::AssetBrowser(Scene* scene, VulkanImGuiOverlay* overlay, bool open)
-		: ImGuiWindow("Asset Browser", open), m_Scene(scene), m_Overlay(overlay)
+	AssetBrowser::AssetBrowser(Scene* scene, EditorUI* editorUI, bool open)
+		: ImGuiWindow("Asset Browser", open), m_Scene(scene), m_EditorUI(editorUI)
 	{
 		m_CurrentPath = std::filesystem::path("Assets");
 	}
@@ -54,13 +54,13 @@ namespace Nightbird
 					if (path.extension() == ".scene" && m_Scene)
 					{
 						m_Scene->LoadSceneBIN(path.string());
-						m_Overlay->SelectObject(nullptr);
+						m_EditorUI->SelectObject(nullptr);
 						break;
 					}
 					else if (path.extension() == ".tscene" && m_Scene)
 					{
 						m_Scene->LoadSceneJSON(path.string());
-						m_Overlay->SelectObject(nullptr);
+						m_EditorUI->SelectObject(nullptr);
 						break;
 					}
 				}

--- a/Editor/Source/Private/EditorRenderTarget.cpp
+++ b/Editor/Source/Private/EditorRenderTarget.cpp
@@ -3,7 +3,7 @@
 #include <Core/Engine.h>
 #include <Core/Renderer.h>
 #include <Vulkan/Texture.h>
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 #include <SceneWindow.h>
 
 #include <Vulkan/Instance.h>
@@ -16,7 +16,7 @@ namespace Nightbird
 	EditorRenderTarget::EditorRenderTarget(Renderer* renderer, VulkanInstance* instance, VulkanDevice* device, VulkanSwapChain* swapChain, VulkanRenderPass* renderPass, GLFWwindow* glfwWindow, Scene* scene, ModelManager* modelManager)
 		: RenderTarget(renderer)
 	{
-		imGuiOverlay = std::make_unique<VulkanImGuiOverlay>(instance, device, swapChain, renderPass, glfwWindow, scene, modelManager);
+		editorUI = std::make_unique<EditorUI>(instance, device, swapChain, renderPass, glfwWindow, scene, modelManager);
 	}
 
 	EditorRenderTarget::~EditorRenderTarget()
@@ -26,7 +26,7 @@ namespace Nightbird
 	
 	void EditorRenderTarget::Render(Scene* scene, VulkanRenderPass* renderPass, VkCommandBuffer commandBuffer, VkFramebuffer framebuffer, VkExtent2D extent)
 	{
-		SceneWindow* sceneWindow = static_cast<SceneWindow*>(imGuiOverlay->GetWindow("Scene Window"));
+		SceneWindow* sceneWindow = static_cast<SceneWindow*>(editorUI->GetWindow("Scene Window"));
 		if (sceneWindow)
 		{
 			if (sceneWindow->ShouldResize())
@@ -45,7 +45,7 @@ namespace Nightbird
 			sceneWindow->GetColorTexture()->TransitionToShaderRead(commandBuffer);
 
 		renderPass->Begin(commandBuffer, framebuffer, extent);
-		imGuiOverlay->Render(commandBuffer);
+		editorUI->Render(commandBuffer);
 		renderPass->End(commandBuffer);
 	}
 }

--- a/Editor/Source/Private/EditorUI.cpp
+++ b/Editor/Source/Private/EditorUI.cpp
@@ -1,4 +1,4 @@
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 
 #include <vector>
 #include <iostream>
@@ -25,7 +25,7 @@
 
 namespace Nightbird
 {
-	VulkanImGuiOverlay::VulkanImGuiOverlay(VulkanInstance* instance, VulkanDevice* device, VulkanSwapChain* swapChain, VulkanRenderPass* renderPass, GLFWwindow* glfwWindow, Scene* scene, ModelManager* modelManager)
+	EditorUI::EditorUI(VulkanInstance* instance, VulkanDevice* device, VulkanSwapChain* swapChain, VulkanRenderPass* renderPass, GLFWwindow* glfwWindow, Scene* scene, ModelManager* modelManager)
 		: m_Window(glfwWindow), m_Scene(scene)
 	{
 		m_DescriptorPool = std::make_unique<ImGuiDescriptorPool>(device);
@@ -77,14 +77,14 @@ namespace Nightbird
 		m_Windows["About"] = std::make_unique<AboutWindow>();
 	}
 	
-	VulkanImGuiOverlay::~VulkanImGuiOverlay()
+	EditorUI::~EditorUI()
 	{
 		ImGui_ImplVulkan_Shutdown();
 		ImGui_ImplGlfw_Shutdown();
 		ImGui::DestroyContext();
 	}
 
-	ImGuiWindow* VulkanImGuiOverlay::GetWindow(const std::string& title)
+	ImGuiWindow* EditorUI::GetWindow(const std::string& title)
 	{
 		if (m_Windows.count(title))
 		{
@@ -93,17 +93,17 @@ namespace Nightbird
 		return nullptr;
 	}
 	
-	SceneObject* VulkanImGuiOverlay::GetSelectedObject() const
+	SceneObject* EditorUI::GetSelectedObject() const
 	{
 		return m_SelectedObject;
 	}
 
-	void VulkanImGuiOverlay::SelectObject(SceneObject* object)
+	void EditorUI::SelectObject(SceneObject* object)
 	{
 		m_SelectedObject = object;
 	}
 	
-	void VulkanImGuiOverlay::Render(VkCommandBuffer commandBuffer)
+	void EditorUI::Render(VkCommandBuffer commandBuffer)
 	{
 		NewFrame();
 
@@ -169,13 +169,13 @@ namespace Nightbird
 		Draw(commandBuffer);
 	}
 
-	void VulkanImGuiOverlay::OpenWindow(const std::string& title)
+	void EditorUI::OpenWindow(const std::string& title)
 	{
 		if (m_Windows.count(title))
 			m_Windows[title]->SetOpen(true);
 	}
 	
-	void VulkanImGuiOverlay::NewFrame()
+	void EditorUI::NewFrame()
 	{
 		ImGui_ImplVulkan_NewFrame();
 		ImGui_ImplGlfw_NewFrame();
@@ -184,7 +184,7 @@ namespace Nightbird
 		ImGui::DockSpaceOverViewport();
 	}
 	
-	void VulkanImGuiOverlay::Draw(VkCommandBuffer commandBuffer)
+	void EditorUI::Draw(VkCommandBuffer commandBuffer)
 	{
 		ImGui::Render();
 		ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), commandBuffer);

--- a/Editor/Source/Private/Inspector.cpp
+++ b/Editor/Source/Private/Inspector.cpp
@@ -1,6 +1,6 @@
 #include <Inspector.h>
 
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 
 #include <Core/SceneObject.h>
 #include <Core/Scene.h>
@@ -36,15 +36,15 @@ inline glm::vec3 RoundEulerDP(const glm::vec3& angles, int dp)
 
 namespace Nightbird
 {
-	Inspector::Inspector(Scene* scene, VulkanImGuiOverlay* overlay, bool open)
-		: ImGuiWindow("Inspector", open), m_Scene(scene), m_Overlay(overlay)
+	Inspector::Inspector(Scene* scene, EditorUI* editorUI, bool open)
+		: ImGuiWindow("Inspector", open), m_Scene(scene), m_EditorUI(editorUI)
 	{
 
 	}
 
 	void Inspector::OnRender()
 	{
-		SceneObject* selectedObject = m_Overlay->GetSelectedObject();
+		SceneObject* selectedObject = m_EditorUI->GetSelectedObject();
 		if (selectedObject)
 		{
 			RenderProperties(rttr::instance(*selectedObject));

--- a/Editor/Source/Private/SceneOutliner.cpp
+++ b/Editor/Source/Private/SceneOutliner.cpp
@@ -4,14 +4,14 @@
 #include <string>
 #include <iostream>
 
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 #include <Core/Scene.h>
 #include <Core/PrefabInstance.h>
 
 namespace Nightbird
 {
-	SceneOutliner::SceneOutliner(Scene* scene, VulkanImGuiOverlay* overlay, bool open)
-		: ImGuiWindow("Scene Outliner", open, ImGuiWindowProperties{true}), m_Scene(scene), m_Overlay(overlay)
+	SceneOutliner::SceneOutliner(Scene* scene, EditorUI* editorUI, bool open)
+		: ImGuiWindow("Scene Outliner", open, ImGuiWindowProperties{true}), m_Scene(scene), m_EditorUI(editorUI)
 	{
 
 	}
@@ -24,17 +24,17 @@ namespace Nightbird
 			{
 				if (ImGui::MenuItem("New Scene Object"))
 				{
-					m_Overlay->OpenWindow("Create Object Window");
+					m_EditorUI->OpenWindow("Create Object Window");
 				}
 				if (ImGui::MenuItem("Instantiate Model"))
 				{
-					m_Overlay->OpenWindow("Instantiate Model Window");
+					m_EditorUI->OpenWindow("Instantiate Model Window");
 				}
 				ImGui::EndMenu();
 			}
 			if (ImGui::BeginMenu("Load Model"))
 			{
-				m_Overlay->OpenWindow("Load Model Window");
+				m_EditorUI->OpenWindow("Load Model Window");
 				ImGui::EndMenu();
 			}
 			ImGui::EndMenuBar();
@@ -68,7 +68,7 @@ namespace Nightbird
 			return;
 
 		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow;
-		if (object == m_Overlay->GetSelectedObject())
+		if (object == m_EditorUI->GetSelectedObject())
 			flags |= ImGuiTreeNodeFlags_Selected;
 
 		if (object->GetChildren().empty() || dynamic_cast<PrefabInstance*>(object))
@@ -77,7 +77,7 @@ namespace Nightbird
 		bool opened = ImGui::TreeNodeEx(object, flags, "%s", object->GetName().c_str());
 
 		if (ImGui::IsItemClicked())
-			m_Overlay->SelectObject(object);
+			m_EditorUI->SelectObject(object);
 
 		if (ImGui::BeginDragDropSource())
 		{

--- a/Editor/Source/Public/AssetBrowser.h
+++ b/Editor/Source/Public/AssetBrowser.h
@@ -7,19 +7,19 @@
 namespace Nightbird
 {
 	class Scene;
-	class VulkanImGuiOverlay;
+	class EditorUI;
 
 	class AssetBrowser : public ImGuiWindow
 	{
 	public:
-		AssetBrowser(Scene* scene, VulkanImGuiOverlay* overlay, bool open = true);
+		AssetBrowser(Scene* scene, EditorUI* editorUI, bool open = true);
 
 	protected:
 		void OnRender() override;
 
 		Scene* m_Scene = nullptr;
 
-		VulkanImGuiOverlay* m_Overlay;
+		EditorUI* m_EditorUI;
 		
 		std::filesystem::path m_CurrentPath;
 		std::filesystem::path m_SelectedPath;

--- a/Editor/Source/Public/CreateObjectWindow.h
+++ b/Editor/Source/Public/CreateObjectWindow.h
@@ -7,7 +7,6 @@
 namespace Nightbird
 {
 	class Scene;
-	class VulkanImGuiOverlay;
 	
 	class CreateObjectWindow : public ImGuiWindow
 	{

--- a/Editor/Source/Public/EditorRenderTarget.h
+++ b/Editor/Source/Public/EditorRenderTarget.h
@@ -2,7 +2,7 @@
 
 #include <Core/RenderTarget.h>
 
-#include <ImGuiOverlay.h>
+#include <EditorUI.h>
 
 namespace Nightbird
 {
@@ -20,6 +20,6 @@ namespace Nightbird
 		void Render(Scene* scene, VulkanRenderPass* renderPass, VkCommandBuffer commandBuffer, VkFramebuffer framebuffer, VkExtent2D extent) override;
 
 	private:
-		std::unique_ptr<VulkanImGuiOverlay> imGuiOverlay;
+		std::unique_ptr<EditorUI> editorUI;
 	};
 }

--- a/Editor/Source/Public/EditorUI.h
+++ b/Editor/Source/Public/EditorUI.h
@@ -25,11 +25,11 @@ namespace Nightbird
 	class Scene;
 	class ModelManager;
 	
-	class VulkanImGuiOverlay
+	class EditorUI
 	{
 	public:
-		VulkanImGuiOverlay(VulkanInstance* instance, VulkanDevice* device, VulkanSwapChain* swapChain, VulkanRenderPass* renderPass, GLFWwindow* glfwWindow, Scene* scene, ModelManager* modelManager);
-		~VulkanImGuiOverlay();
+		EditorUI(VulkanInstance* instance, VulkanDevice* device, VulkanSwapChain* swapChain, VulkanRenderPass* renderPass, GLFWwindow* glfwWindow, Scene* scene, ModelManager* modelManager);
+		~EditorUI();
 		
 		ImGuiWindow* GetWindow(const std::string& title);
 		

--- a/Editor/Source/Public/Inspector.h
+++ b/Editor/Source/Public/Inspector.h
@@ -7,14 +7,14 @@
 
 namespace Nightbird
 {
-	class VulkanImGuiOverlay;
+	class EditorUI;
 	class SceneObject;
 	class Scene;
 
 	class Inspector : public ImGuiWindow
 	{
 	public:
-		Inspector(Scene* scene, VulkanImGuiOverlay* overlay, bool open = true);
+		Inspector(Scene* scene, EditorUI* editorUI, bool open = true);
 
 	protected:
 		void OnRender() override;
@@ -22,7 +22,7 @@ namespace Nightbird
 		void RenderProperties(rttr::instance instance);
 		
 		Scene* m_Scene = nullptr;
-		VulkanImGuiOverlay* m_Overlay = nullptr;
+		EditorUI* m_EditorUI = nullptr;
 
 		SceneObject* m_SelectedObject = nullptr;
 	};

--- a/Editor/Source/Public/SceneOutliner.h
+++ b/Editor/Source/Public/SceneOutliner.h
@@ -8,13 +8,13 @@
 
 namespace Nightbird
 {
-	class VulkanImGuiOverlay;
+	class EditorUI;
 	class Scene;
 	
 	class SceneOutliner : public ImGuiWindow
 	{
 	public:
-		SceneOutliner(Scene* scene, VulkanImGuiOverlay* overlay, bool open = true);
+		SceneOutliner(Scene* scene, EditorUI* editorUI, bool open = true);
 
 	protected:
 		void OnRender() override;
@@ -22,6 +22,6 @@ namespace Nightbird
 		void SceneOutliner::DrawSceneNode(SceneObject* object, bool& dropHandled);
 
 		Scene* m_Scene = nullptr;
-		VulkanImGuiOverlay* m_Overlay = nullptr;
+		EditorUI* m_EditorUI = nullptr;
 	};
 }


### PR DESCRIPTION
ImGuiOverlay was a legacy name from when Dear ImGui was used only as a UI overlay rather than a full editor.